### PR TITLE
Specify a netmask for the ip addresses to pass to ./bin/pipework.

### DIFF
--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -23,7 +23,7 @@ do
 
   sleep 1
 
-  sudo ./bin/pipework br1 ${CONTAINER_ID} "33.33.33.${index}0"
+  sudo ./bin/pipework br1 ${CONTAINER_ID} "33.33.33.${index}0/24"
 
   echo "Started [riak${index}] and assigned it the IP [33.33.33.${index}0]"
 


### PR DESCRIPTION
Without it, you get the following error.

```
$ make riak-container
./bin/start-cluster.sh
The IP address should include a netmask.
Maybe you meant 33.33.33.10/24 ?
make: *** [start-cluster] Error 1
```
