### PR TITLE
convert localhost to 127.0.0.1

### DIFF
--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -40,7 +40,7 @@ do
   CONTAINER_ID=$(docker ps | egrep "riak${index}[^/]" | cut -d" " -f1)
   CONTAINER_PORT=$(docker port "${CONTAINER_ID}" 8098 | cut -d ":" -f2)
 
-  until curl -s "http://localhost:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
+  until curl -s "http://127.0.0.1:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
   do
     sleep 3
   done

--- a/bin/test-cluster.sh
+++ b/bin/test-cluster.sh
@@ -9,4 +9,4 @@ fi
 RANDOM_CONTAINER_ID=$(docker ps | egrep "hectcastro/riak" | cut -d" " -f1 | perl -MList::Util=shuffle -e'print shuffle<>' | head -n1)
 CONTAINER_HTTP_PORT=$(docker port "${RANDOM_CONTAINER_ID}" 8098 | cut -d ":" -f2)
 
-curl -s "http://localhost:${CONTAINER_HTTP_PORT}/stats" | python -mjson.tool
+curl -s "http://127.0.0.1:${CONTAINER_HTTP_PORT}/stats" | python -mjson.tool


### PR DESCRIPTION
A specific ip address is a bit more tolerant of certain VM port forwarding implementations.

In my case, the `start-cluster.sh` script would hang here:

```
until curl -s "http://localhost:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
do
    sleep 3
done
```

because curl -s would never return anything.
