### PR TITLE
Updating start/test cluster scripts to support the docker client

### DIFF
--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -6,6 +6,7 @@ if env | grep -q "DOCKER_RIAK_DEBUG"; then
   set -x
 fi
 
+CLEAN_DOCKER_HOST=$(echo "${DOCKER_HOST}" | cut -d'/' -f3 | cut -d':' -f1)
 DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE:-5}
 
 if docker ps -a | grep "hectcastro/riak" >/dev/null; then
@@ -68,7 +69,7 @@ do
   CONTAINER_ID=$(docker ps | egrep "riak${index}[^/]" | cut -d" " -f1)
   CONTAINER_PORT=$(docker port "${CONTAINER_ID}" 8098 | cut -d ":" -f2)
 
-  until curl -s "http://127.0.0.1:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
+  until curl -s "http://${CLEAN_DOCKER_HOST}:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
   do
     sleep 3
   done

--- a/bin/test-cluster.sh
+++ b/bin/test-cluster.sh
@@ -6,7 +6,8 @@ if env | grep -q "DOCKER_RIAK_DEBUG"; then
   set -x
 fi
 
+CLEAN_DOCKER_HOST=$(echo "${DOCKER_HOST}" | cut -d'/' -f3 | cut -d':' -f1)
 RANDOM_CONTAINER_ID=$(docker ps | egrep "hectcastro/riak" | cut -d" " -f1 | perl -MList::Util=shuffle -e'print shuffle<>' | head -n1)
 CONTAINER_HTTP_PORT=$(docker port "${RANDOM_CONTAINER_ID}" 8098 | cut -d ":" -f2)
 
-curl -s "http://127.0.0.1:${CONTAINER_HTTP_PORT}/stats" | python -mjson.tool
+curl -s "http://${CLEAN_DOCKER_HOST}:${CONTAINER_HTTP_PORT}/stats" | python -mjson.tool


### PR DESCRIPTION
When DOCKER_HOST is set and docker is being used as a client, having 127.0.0.1
hard coded causes issues
