### PR TITLE
Upgrade to Riak 2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Hector Castro hectcastro@gmail.com
 
 # Environmental variables
 ENV DEBIAN_FRONTEND noninteractive
-ENV RIAK_VERSION 2.0.1-1
+ENV RIAK_VERSION 2.0.2-1
 
 # Install Java 7
 RUN sed -i.bak 's/main$/main universe/' /etc/apt/sources.list


### PR DESCRIPTION
Resolves “Erlang closed the connection.” errors (also reported by arashm on https://registry.hub.docker.com/u/hectcastro/riak/
