### PR TITLE
fix issue of the riak installation script download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -qq && apt-get install -y software-properties-common && \
     apt-get install -y oracle-java7-installer
 
 # Install Riak
-RUN curl https://packagecloud.io/install/repositories/basho/riak/script.deb | bash
+RUN curl https://packagecloud.io/install/repositories/basho/riak/script.deb.sh | bash
 RUN apt-get install -y riak=${RIAK_VERSION}
 
 # Setup the Riak service


### PR DESCRIPTION
Step 6 of the build fails because the download of the script.deb fails. It looks like the filename had been changed and redirect didn't work as expected. The patch below fix this issue. 