### PR TITLE
Fix boot2docker and improve output/progress

### DIFF
--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -59,7 +59,7 @@ DOCKER_RIAK_PROTO_BUF_PORT_OFFSET=${DOCKER_RIAK_PROTO_BUF_PORT_OFFSET:-100}
 
 for index in $(seq "1" "${DOCKER_RIAK_CLUSTER_SIZE}");
 do
-  index=$(printf "%.2d" $index)
+  index=$(printf "%.2d" "$index")
   if [[ ! -z $DOCKER_RIAK_BASE_HTTP_PORT ]] ; then
     final_http_port=$((DOCKER_RIAK_BASE_HTTP_PORT + index))
     final_pb_port=$((DOCKER_RIAK_BASE_HTTP_PORT + index + DOCKER_RIAK_PROTO_BUF_PORT_OFFSET))

--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -57,9 +57,9 @@ publish_pb_port="8087"
 
 DOCKER_RIAK_PROTO_BUF_PORT_OFFSET=${DOCKER_RIAK_PROTO_BUF_PORT_OFFSET:-100}
 
-for index in $(seq -f "%02g" "1" "${DOCKER_RIAK_CLUSTER_SIZE}");
+for index in $(seq "1" "${DOCKER_RIAK_CLUSTER_SIZE}");
 do
-
+  index=$(printf "%.2d" $index)
   if [[ ! -z $DOCKER_RIAK_BASE_HTTP_PORT ]] ; then
     final_http_port=$((DOCKER_RIAK_BASE_HTTP_PORT + index))
     final_pb_port=$((DOCKER_RIAK_BASE_HTTP_PORT + index + DOCKER_RIAK_PROTO_BUF_PORT_OFFSET))
@@ -85,16 +85,18 @@ do
                --name "riak${index}" \
                -d hectcastro/riak > /dev/null 2>&1
   fi
+  echo -n "Starting riak${index}:"
 
   CONTAINER_ID=$(docker ps | egrep "riak${index}[^/]" | cut -d" " -f1)
   CONTAINER_PORT=$(docker port "${CONTAINER_ID}" 8098 | cut -d ":" -f2)
 
-  until curl -s "http://${CLEAN_DOCKER_HOST}:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
+  until curl -m 1 -s "http://${CLEAN_DOCKER_HOST}:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
   do
+    echo -n "."
     sleep 3
   done
 
-  echo "  Successfully brought up [riak${index}]"
+  echo "  Complete"
 done
 
 echo


### PR DESCRIPTION
boot2docker appears to use an older version of bash (if it is installed at all) and causes issues with the `seq` utility

I also found that the curl command would hang for a number of seconds on the initial test if the service hadn't started - slowing down the building of the cluster