### PR TITLE
use /usr/bin/env to find bash

### DIFF
--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -e
 

--- a/bin/stop-cluster.sh
+++ b/bin/stop-cluster.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -e
 

--- a/bin/test-cluster.sh
+++ b/bin/test-cluster.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
[Not everybody](https://nixos.org/) has a `/bin/bash`. `/usr/bin/env bash` should be a safe replacement.