### PR TITLE
weaken DOCKER_HOST guard for environments that do not use DOCKER_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ This is a [Docker](http://docker.io) project to bring up a local
 Follow the [instructions on Docker's website](https://www.docker.io/gettingstarted/#h_installation)
 to install Docker.
 
-From there, ensure that your `DOCKER_HOST` environmental variable is set
-correctly:
+Many (but not all) Docker environments set the `DOCKER_HOST`
+environment variable to help the client find the Docker host. Some
+environments use a Unix domain socket by default.
+
+If your Docker client connects to the Docker host via TCP, ensure that
+your `DOCKER_HOST` environmental variable is set correctly:
 
 ```bash
 $ export DOCKER_HOST="tcp://127.0.0.1:2375"

--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -6,22 +6,14 @@ if env | grep -q "DOCKER_RIAK_DEBUG"; then
   set -x
 fi
 
-if [ -z "${DOCKER_HOST}" ]; then
-  echo ""
-  echo "It looks like the environment variable DOCKER_HOST has not"
-  echo "been set.  The Riak cluster cannot be started unless this has"
-  echo "been set appropriately.  For example:"
-  echo ""
-  echo "  export DOCKER_HOST=\"tcp://127.0.0.1:2375\""
-  echo ""
+CLEAN_DOCKER_HOST="localhost"
 
-  exit 1
-fi
-
-if [[ "${DOCKER_HOST}" == unix://* ]]; then
-  CLEAN_DOCKER_HOST="localhost"
-else
-  CLEAN_DOCKER_HOST=$(echo "${DOCKER_HOST}" | cut -d'/' -f3 | cut -d':' -f1)
+if [ "${DOCKER_HOST}" ]; then
+  if [[ "${DOCKER_HOST}" == unix://* ]]; then
+    CLEAN_DOCKER_HOST="localhost"
+  else
+    CLEAN_DOCKER_HOST=$(echo "${DOCKER_HOST}" | cut -d'/' -f3 | cut -d':' -f1)
+  fi
 fi
 
 DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE:-5}

--- a/bin/test-cluster.sh
+++ b/bin/test-cluster.sh
@@ -6,10 +6,14 @@ if env | grep -q "DOCKER_RIAK_DEBUG"; then
   set -x
 fi
 
-if [[ "${DOCKER_HOST}" == unix://* ]]; then
-  CLEAN_DOCKER_HOST="localhost"
-else
-  CLEAN_DOCKER_HOST=$(echo "${DOCKER_HOST}" | cut -d'/' -f3 | cut -d':' -f1)
+CLEAN_DOCKER_HOST="localhost"
+
+if [ "${DOCKER_HOST}" ]; then
+  if [[ "${DOCKER_HOST}" == unix://* ]]; then
+    CLEAN_DOCKER_HOST="localhost"
+  else
+    CLEAN_DOCKER_HOST=$(echo "${DOCKER_HOST}" | cut -d'/' -f3 | cut -d':' -f1)
+  fi
 fi
 
 RANDOM_CONTAINER_ID=$(docker ps | egrep "hectcastro/riak" | cut -d" " -f1 | perl -MList::Util=shuffle -e'print shuffle<>' | head -n1)


### PR DESCRIPTION
This change weakens the DOCKER_HOST guard in the start and test scripts to allow Docker environments that do not use DOCKER_HOST (e.g., Digital Ocean's Docker droplet). If DOCKER_HOST is set, the previous checks still apply; if it is not set, we default to `localhost`.