### PR TITLE
improvements on start/stop scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,6 @@ test-cluster:
 
 stop-cluster:
 	./bin/stop-cluster.sh
+
+remove-cluster:
+	./bin/remove-cluster.sh

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ $ DOCKER_RIAK_AUTOMATIC_CLUSTERING=1 DOCKER_RIAK_CLUSTER_SIZE=5 DOCKER_RIAK_BACK
 
 Bringing up cluster nodes:
 
-  Successfully brought up [riak01]
-  Successfully brought up [riak02]
-  Successfully brought up [riak03]
-  Successfully brought up [riak04]
-  Successfully brought up [riak05]
+Starting riak01..... Completed
+Starting riak02..... Completed
+Starting riak03..... Completed
+Starting riak04..... Completed
+Starting riak05..... Completed
 
 Please wait approximately 30 seconds for the cluster to stabilize.
 ```
@@ -164,10 +164,18 @@ $ ssh -i insecure_key root@172.17.0.2
 [boot2docker](https://github.com/boot2docker/boot2docker), ensure that you're
 issuing the SSH command from within the virtual machine running `boot2docker`.
 
-## Destroying
+## Stopping
 
 ```bash
 $ make stop-cluster
 ./bin/stop-cluster.sh
+Stopped all of the running containers.
+```
+
+## Destroying
+
+```bash
+$ make remove-cluster
+./bin/remove-cluster.sh
 Stopped the cluster and cleared all of the running containers.
 ```

--- a/bin/remove-cluster.sh
+++ b/bin/remove-cluster.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+if env | grep -q "DOCKER_RIAK_DEBUG"; then
+  set -x
+fi
+
+docker ps -a | egrep "hectcastro/riak" | cut -d " " -f1 | xargs -I{} docker rm -f {} > /dev/null 2>&1
+
+echo "Stopped the cluster and cleared all of the running containers."

--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 function start_exited_riak_containers {
-  containers=`docker ps -a -f "status=exited" --format "table {{.Names}}\t{{.ID}}\t{{.Image}}" | grep "hectcastro/riak" || :`
+  containers=$(docker ps -a -f "status=exited" --format "table {{.Names}}\t{{.ID}}\t{{.Image}}" | grep "hectcastro/riak" || :)
   if [[ ! -z $containers ]]; then
     echo "Bringing up stopped docker instances."
     echo "$containers" | sort -V | while read -r container; 
     do
-      CONTAINER_ID=`echo $container | awk '{print $2}'`
-      CONTAINER_NAME=`echo $container | awk '{print $1}'`
+      CONTAINER_ID=$(echo "$container" | awk '{print $2}')
+      CONTAINER_NAME=$(echo "$container" | awk '{print $1}')
       echo -n "Starting ${CONTAINER_NAME}..."
-      docker start ${CONTAINER_ID} > /dev/null 2>&1  
+      docker start "${CONTAINER_ID}" > /dev/null 2>&1  
       echo " Completed"
     done
 

--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -1,5 +1,93 @@
 #!/usr/bin/env bash
 
+function start_exited_riak_containers {
+  containers=`docker ps -a -f "status=exited" --format "table {{.Names}}\t{{.ID}}\t{{.Image}}" | grep "hectcastro/riak" || :`
+  if [[ ! -z $containers ]]; then
+    echo "Bringing up stopped docker instances."
+    echo "$containers" | sort -V | while read -r container; 
+    do
+      CONTAINER_ID=`echo $container | awk '{print $2}'`
+      CONTAINER_NAME=`echo $container | awk '{print $1}'`
+      echo -n "Starting ${CONTAINER_NAME}..."
+      docker start ${CONTAINER_ID} > /dev/null 2>&1  
+      echo " Completed"
+    done
+
+    echo
+    echo "Please wait approximately 30 seconds for the cluster to stabilize."
+    echo
+  fi
+}
+
+function start_new_riak_cluter {
+  
+  # The default allows Docker to forward arbitrary ports on the VM for the Riak
+  # containers. Ports used by default are usually in the 49xx range.
+
+  publish_http_port="8098"
+  publish_pb_port="8087"
+
+  # If DOCKER_RIAK_BASE_HTTP_PORT is set, port number
+  # $DOCKER_RIAK_BASE_HTTP_PORT + $index gets forwarded to 8098 and
+  # $DOCKER_RIAK_BASE_HTTP_PORT + $index + $DOCKER_RIAK_PROTO_BUF_PORT_OFFSET
+  # gets forwarded to 8087. DOCKER_RIAK_PROTO_BUF_PORT_OFFSET is optional and
+  # defaults to 100.
+
+  DOCKER_RIAK_PROTO_BUF_PORT_OFFSET=${DOCKER_RIAK_PROTO_BUF_PORT_OFFSET:-100}
+  
+  echo
+  echo "Bringing up cluster nodes:"
+  echo
+
+  for index in $(seq "1" "${DOCKER_RIAK_CLUSTER_SIZE}");
+  do
+    index=$(printf "%.2d" "$index")
+    if [[ ! -z $DOCKER_RIAK_BASE_HTTP_PORT ]] ; then
+      final_http_port=$((DOCKER_RIAK_BASE_HTTP_PORT + index))
+      final_pb_port=$((DOCKER_RIAK_BASE_HTTP_PORT + index + DOCKER_RIAK_PROTO_BUF_PORT_OFFSET))
+      publish_http_port="${final_http_port}:8098"
+      publish_pb_port="${final_pb_port}:8087"
+    fi
+
+    if [ "${index}" -gt "1" ] ; then
+      docker run -e "DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE}" \
+                 -e "DOCKER_RIAK_AUTOMATIC_CLUSTERING=${DOCKER_RIAK_AUTOMATIC_CLUSTERING}" \
+                 -e "DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND}" \
+                 -e "DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY}" \
+                 -p $publish_http_port \
+                 -p $publish_pb_port \
+                 --link "riak01:seed" \
+                 --name "riak${index}" \
+                 -d hectcastro/riak > /dev/null 2>&1
+    else
+      docker run -e "DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE}" \
+                 -e "DOCKER_RIAK_AUTOMATIC_CLUSTERING=${DOCKER_RIAK_AUTOMATIC_CLUSTERING}" \
+                 -e "DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND}" \
+                 -e "DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY}" \
+                 -p $publish_http_port \
+                 -p $publish_pb_port \
+                 --name "riak${index}" \
+                 -d hectcastro/riak > /dev/null 2>&1
+    fi
+    echo -n "Starting riak${index}..."
+
+    CONTAINER_ID=$(docker ps | grep "riak${index}" | cut -d" " -f1)
+    CONTAINER_PORT=$(docker port "${CONTAINER_ID}" 8098 | cut -d ":" -f2)
+
+    until curl -m 1 -s "http://${CLEAN_DOCKER_HOST}:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
+    do
+      echo -n "."
+      sleep 3
+    done
+
+    echo " Completed"
+  done
+
+  echo
+  echo "Please wait approximately 30 seconds for the cluster to stabilize."
+  echo
+}
+
 set -e
 
 if env | grep -q "DOCKER_RIAK_DEBUG"; then
@@ -22,78 +110,13 @@ DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY:-off}
 
 if docker ps -a | grep "hectcastro/riak" >/dev/null; then
   echo ""
-  echo "It looks like you already have some Riak containers running."
-  echo "Please take them down before attempting to bring up another"
-  echo "cluster with the following command:"
+  echo "It looks like you already have some Riak containers."
+  echo "If you want to start a new Riak cluster then please"
+  echo "remove them first with the following command:"
   echo ""
-  echo "  make stop-cluster"
+  echo "  make remove-cluster"
   echo ""
-
-  exit 1
+  start_exited_riak_containers
+else
+  start_new_riak_cluter
 fi
-
-echo
-echo "Bringing up cluster nodes:"
-echo
-
-# The default allows Docker to forward arbitrary ports on the VM for the Riak
-# containers. Ports used by default are usually in the 49xx range.
-
-publish_http_port="8098"
-publish_pb_port="8087"
-
-# If DOCKER_RIAK_BASE_HTTP_PORT is set, port number
-# $DOCKER_RIAK_BASE_HTTP_PORT + $index gets forwarded to 8098 and
-# $DOCKER_RIAK_BASE_HTTP_PORT + $index + $DOCKER_RIAK_PROTO_BUF_PORT_OFFSET
-# gets forwarded to 8087. DOCKER_RIAK_PROTO_BUF_PORT_OFFSET is optional and
-# defaults to 100.
-
-DOCKER_RIAK_PROTO_BUF_PORT_OFFSET=${DOCKER_RIAK_PROTO_BUF_PORT_OFFSET:-100}
-
-for index in $(seq "1" "${DOCKER_RIAK_CLUSTER_SIZE}");
-do
-  index=$(printf "%.2d" "$index")
-  if [[ ! -z $DOCKER_RIAK_BASE_HTTP_PORT ]] ; then
-    final_http_port=$((DOCKER_RIAK_BASE_HTTP_PORT + index))
-    final_pb_port=$((DOCKER_RIAK_BASE_HTTP_PORT + index + DOCKER_RIAK_PROTO_BUF_PORT_OFFSET))
-    publish_http_port="${final_http_port}:8098"
-    publish_pb_port="${final_pb_port}:8087"
-  fi
-
-  if [ "${index}" -gt "1" ] ; then
-    docker run -e "DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE}" \
-               -e "DOCKER_RIAK_AUTOMATIC_CLUSTERING=${DOCKER_RIAK_AUTOMATIC_CLUSTERING}" \
-               -e "DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND}" \
-               -e "DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY}" \
-               -p $publish_http_port \
-               -p $publish_pb_port \
-               --link "riak01:seed" \
-               --name "riak${index}" \
-               -d hectcastro/riak > /dev/null 2>&1
-  else
-    docker run -e "DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE}" \
-               -e "DOCKER_RIAK_AUTOMATIC_CLUSTERING=${DOCKER_RIAK_AUTOMATIC_CLUSTERING}" \
-               -e "DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND}" \
-               -e "DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY}" \
-               -p $publish_http_port \
-               -p $publish_pb_port \
-               --name "riak${index}" \
-               -d hectcastro/riak > /dev/null 2>&1
-  fi
-  echo -n "Starting riak${index}: "
-
-  CONTAINER_ID=$(docker ps | grep "riak${index}" | cut -d" " -f1)
-  CONTAINER_PORT=$(docker port "${CONTAINER_ID}" 8098 | cut -d ":" -f2)
-
-  until curl -m 1 -s "http://${CLEAN_DOCKER_HOST}:${CONTAINER_PORT}/ping" | grep "OK" > /dev/null 2>&1;
-  do
-    echo -n "."
-    sleep 3
-  done
-
-  echo " Complete"
-done
-
-echo
-echo "Please wait approximately 30 seconds for the cluster to stabilize."
-echo

--- a/bin/stop-cluster.sh
+++ b/bin/stop-cluster.sh
@@ -6,6 +6,6 @@ if env | grep -q "DOCKER_RIAK_DEBUG"; then
   set -x
 fi
 
-docker ps | egrep "hectcastro/riak" | cut -d" " -f1 | xargs -I{} docker rm -f {} > /dev/null 2>&1
+docker ps | egrep "hectcastro/riak" | cut -d " " -f1 | xargs -I{} docker stop {} > /dev/null 2>&1
 
-echo "Stopped the cluster and cleared all of the running containers."
+echo "Stopped all of the running containers."


### PR DESCRIPTION
remove-cluster.sh -> new script that uses "docker rm" in order to erase the entire cluster
stop-cluster.sh -> updated to use "docker stop" thus not removing the cluster
start-cluster.sh -> updated to contemplate the start of stopped riak docker instances