### PR TITLE
update riak version and number of file descriptors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Hector Castro hectcastro@gmail.com
 
 # Environmental variables
 ENV DEBIAN_FRONTEND noninteractive
-ENV RIAK_VERSION 2.0.2-1
+ENV RIAK_VERSION 2.1.4-1
 
 RUN \
 

--- a/bin/riak.sh
+++ b/bin/riak.sh
@@ -7,7 +7,7 @@ chown riak:riak /var/lib/riak /var/log/riak
 chmod 755 /var/lib/riak /var/log/riak
 
 # Open file descriptor limit
-ulimit -n 4096
+ulimit -n 65536
 
 # Ensure the Erlang node name is set correctly
 sed -i.bak "s/riak@127.0.0.1/riak@${IP_ADDRESS}/" /etc/riak/riak.conf


### PR DESCRIPTION
- update riak version from 2.0.2-1 to 2.1.4-1
- adjust maximum number of file descriptors from 4096 to 65536
