### PR TITLE
Add option to run riak as a standalone process (not an runit service)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,12 @@ RUN \
     # Cleanup
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Setup the Riak service
-RUN mkdir -p /etc/service/riak
-ADD bin/riak.sh /etc/service/riak/run
+# Setup runtime riak.conf changes
+ADD bin/riak_conf.sh /etc/my_init.d/97_riak_conf.sh
+
+# Setup riak initialization scripts
+ADD bin/run_riak.sh /usr/local/bin/run_riak.sh
+ADD bin/init_riak.sh /etc/my_init.d/98_riak_init.sh
 
 # Setup automatic clustering
 ADD bin/automatic_clustering.sh /etc/my_init.d/99_automatic_clustering.sh

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ make build
 - `DOCKER_RIAK_BACKEND` - Optional Riak backend to use (default: `bitcask`)
 - `DOCKER_RIAK_STRONG_CONSISTENCY` - Enables strong consistency subsystem (values: `on` or `off`, default: `off`)
 - `DOCKER_RIAK_SEARCH` - Enables search (values: `on` or `off`, default: `off`)
+- `DOCKER_RIAK_SERVICE` - Runs Riak as an runit service (values: `1` or `0`, default: `1`). If `0`, Riak will simply be run as a background process, and will not automatically restart if killed.
 
 ### Launch cluster
 

--- a/bin/init_riak.sh
+++ b/bin/init_riak.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# If riak should be run as an runit service, simply symlink the run script to
+# /etc/service/riak/run.
+#
+# Otherwise, exec riak here in the background.
+if env | grep -q "DOCKER_RIAK_SERVICE=1"; then
+  mkdir -p /etc/service/riak
+  ln -s /usr/local/bin/run_riak.sh /etc/service/riak/run
+else
+  /usr/local/bin/run_riak.sh &
+fi

--- a/bin/riak_conf.sh
+++ b/bin/riak_conf.sh
@@ -20,7 +20,3 @@ sed -i.bak "s/## strong_consistency = \(.*\)/strong_consistency = ${DOCKER_RIAK_
 
 # Ensure the search property is set correctly
 sed -i.bak "s/search = \(.*\)/search = ${DOCKER_RIAK_SEARCH}/" /etc/riak/riak.conf
-
-# Start Riak
-exec /sbin/setuser riak "$(ls -d /usr/lib/riak/erts*)/bin/run_erl" "/tmp/riak" \
-   "/var/log/riak" "exec /usr/sbin/riak console"

--- a/bin/run_riak.sh
+++ b/bin/run_riak.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Start Riak
+exec /sbin/setuser riak "$(ls -d /usr/lib/riak/erts*)/bin/run_erl" "/tmp/riak" \
+   "/var/log/riak" "exec /usr/sbin/riak console"

--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -55,6 +55,7 @@ function start_new_riak_cluter {
                  -e "DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND}" \
                  -e "DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY}" \
                  -e "DOCKER_RIAK_SEARCH=${DOCKER_RIAK_SEARCH}" \
+                 -e "DOCKER_RIAK_SERVICE=${DOCKER_RIAK_SERVICE}" \
                  -p $publish_http_port \
                  -p $publish_pb_port \
                  --link "riak01:seed" \
@@ -66,6 +67,7 @@ function start_new_riak_cluter {
                  -e "DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND}" \
                  -e "DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY}" \
                  -e "DOCKER_RIAK_SEARCH=${DOCKER_RIAK_SEARCH}" \
+                 -e "DOCKER_RIAK_SERVICE=${DOCKER_RIAK_SERVICE}" \
                  -p $publish_http_port \
                  -p $publish_pb_port \
                  --name "riak${index}" \
@@ -110,6 +112,7 @@ DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE:-5}
 DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND:-bitcask}
 DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY:-off}
 DOCKER_RIAK_SEARCH=${DOCKER_RIAK_SEARCH:-off}
+DOCKER_RIAK_SERVICE=${DOCKER_RIAK_SERVICE:-1}
 
 if docker ps -a | grep "hectcastro/riak" >/dev/null; then
   echo ""


### PR DESCRIPTION
This PR makes two changes:
1. The in-place seds and other misc. setup are moved from `riak.sh` to an init script, so that if riak is restarted by `runit`, these are not re-run unnecessarily.
2. The riak exec script is placed at `/usr/local/bin/run_riak.sh` rather than `/etc/service/riak/run`. Then, an environment variable controlls whether a new init script (`init_riak.sh`) symlinks `/usr/local/bin/run_riak.sh` to `/etc/service/riak/run`, or simply runs it as a background process.

By allowing riak to run outside of runit, I can do things like `riak restart` from test code that will behave "as intended", i.e. riak and runit will not fight each other over starting the node.
